### PR TITLE
Fix LSM calculation

### DIFF
--- a/MATLAB/ampd.m
+++ b/MATLAB/ampd.m
@@ -47,7 +47,7 @@ function varargout = ampd(Signal)
 
     for k=1:L
         for i=k+2:N-k+1
-            if(Signal(i-1)>Signal(i-k-1) && Signal(i-1)>Signal(i+k-1))
+            if(dtrSignal(i-1)>dtrSignal(i-k-1) && dtrSignal(i-1)>dtrSignal(i+k-1))
                 LSM(k,i) = 0;
             end
         end


### PR DESCRIPTION
LSM should be calculated with the de-trended signal.

Quote from the paper:

```
The first step of the automatic multiscale-based peak detection (AMPD) algorithm
consists of calculating the local maxima scalogram (LMS). 
To this end, the signal x is first linearly detrended, i.e., the least-squares fit 
of a straight line to x is calculated and subtracted from x.
